### PR TITLE
Fix dashboard stuck on postflight after rearm (governor off)

### DIFF
--- a/docs/dev-notes-dashboard-flightmode-fix.md
+++ b/docs/dev-notes-dashboard-flightmode-fix.md
@@ -1,0 +1,169 @@
+# Dashboard flight-mode stuck-on-postflight fix — dev notes
+
+**Status: implemented, UNTESTED.** No Lua interpreter or scriptable
+simulator driver was available in the session that wrote this, so
+everything below is code-review-verified only, not execution-verified.
+Pick up testing here on whatever machine has the Ethos simulator/radio
+available.
+
+## The bug
+
+Reported symptom: after landing (dashboard on `"postflight"`), rearming
+and spooling back up restarts the flight timer correctly, but the
+dashboard theme stays stuck showing `"postflight"` instead of switching
+back to `"inflight"`. Most noticeable with **governor off**, using
+throttle level to detect "spooled up".
+
+## Root cause (confirmed via git history)
+
+`widgets/dashboard/flightmode.lua`'s `inFlight()` decides "are we
+flying" as: `isArmed AND (governor active OR throttle > 35%)`.
+
+The **"Total rewrite" (#2256)** replaced the pre-rewrite throttle
+signal with a different one, and dropped two state-machine rules in the
+same file. Compare:
+
+- **Pre-rewrite** (`git show 5069ec32^:src/rfsuite/tasks/scheduler/events/tasks/flightmode.lua`):
+  throttle came from `rfsuite.session.rx.values.throttle` — the
+  **radio's own throttle channel**, read locally via
+  `system.getSource({category = CATEGORY_CHANNEL, member = <RX_MAP
+  throttle index>})`. Always current, independent of the aircraft.
+  It also had:
+  ```lua
+  -- reset the instant a fresh arm is detected
+  if armed and not lastArmed then hasBeenInFlight = false; return "preflight" end
+  ...
+  -- hold inflight while still armed, ignoring a momentary throttle/governor blip
+  -- comment: "avoids transient sensor/telemetry gaps flipping to
+  -- postflight mid-flight"
+  if armed and hasBeenInFlight then return "inflight" end
+  ```
+- **Post-rewrite** (current `widgets/dashboard/flightmode.lua`, before
+  this fix): throttle came from `widget.throttlePercent` →
+  `session.throttlePercent` → FC/ESC **telemetry sensor**
+  (`throttle_percent`, `tasks/session.lua`). Neither of the two rules
+  above existed — any tick where the spool-up check read false fell
+  straight through to `"postflight"`, even while still armed.
+
+`lib/msp_handshake.lua` says outright why the RX-channel read didn't
+survive the rewrite:
+
+> "Deliberately excludes rxmap ... which depend on rx-channel-consuming
+> features ... this lite rebuild doesn't have yet"
+
+So it wasn't a deliberate redesign — the RX_MAP/channel-reading
+machinery just hadn't been ported back in, and FC telemetry was subbed
+in as a stand-in. That's a materially different signal, especially with
+governor off, and losing the "hold while armed" rule made it worse: a
+momentary gap (telemetry lag, brief low-throttle moment) bounces the
+dashboard to `"postflight"` mid-flight or right after a rearm, and
+recovering from there depends on that same signal crossing the
+threshold again.
+
+## What this fix does
+
+1. **New**: `lib/msp_rx_map.lua` — reads `MSP_RX_MAP` (cmd 64, standard
+   MultiWii-lineage command, not Rotorflight-specific), decoding the
+   8-byte channel map (aileron/elevator/rudder/collective/throttle/aux1-3).
+   Modeled on the existing `lib/msp_sensor_alignment.lua` pattern.
+2. **`tasks/session.lua`**: fetches RX_MAP once per connect (same gated
+   `if not session.rxMap then ... end` pattern as the other
+   `runHandshake()` reads), stores `session.rxMap`, publishes it in the
+   snapshot, clears it on disconnect.
+3. **`widgets/dashboard.lua`**: threads `snapshot.rxMap` through to
+   `widget.rxMap`, same as every other snapshot field.
+4. **`widgets/dashboard/flightmode.lua`**:
+   - `resolveThrottleChannelValue(widget)`: resolves (and caches, on
+     the widget) `system.getSource({category = CATEGORY_CHANNEL,
+     member = widget.rxMap.throttle})`, matching the pre-rewrite call
+     shape and the **same threshold (35)**, unchanged, on the theory
+     that reusing a value that's already known to have worked is safer
+     than re-deriving a new one from docs alone.
+   - `inFlight()` prefers that channel value; falls back to
+     `widget.throttlePercent` (today's mechanism) only if RX_MAP hasn't
+     resolved yet — so this can't regress below where things stand
+     today even if RX_MAP fails for some reason.
+   - `Tracker:update()` restores the reset-on-rearm and
+     hold-inflight-while-armed rules from the pre-rewrite
+     `determineMode()`.
+
+## What's verified vs. not
+
+**Verified (static/manual review only):**
+- Every new field name (`rxMap`, `_throttleChannelMember`,
+  `_throttleChannelSource`) traced by hand across all four files, no
+  mismatches found.
+- MSP command number (64), field byte order, and the
+  `CATEGORY_CHANNEL`/`system.getSource` call shape all matched exactly
+  against both the pre-rewrite code and the current
+  `app/pages/modes.lua` (which already does the identical channel read
+  for AUX-channel auto-detect).
+
+**NOT verified — needs a real test pass:**
+- No Lua interpreter was available to even syntax-check these files.
+- No way to launch the Ethos simulator from that session — it's gated
+  behind a VS Code extension command (`${command:ethos.start}` in
+  `.vscode/tasks.json`), no headless/scriptable entry point.
+- **Biggest open risk**: the raw channel value's *scale*. The old code
+  compared `source:value()` directly against `35` with zero
+  conversion — this fix does exactly the same, on the assumption that
+  matching old behavior byte-for-byte is safer than guessing a new
+  threshold. If Ethos's default channel-value scale has changed since
+  the pre-rewrite code was written (or differs from assumptions), `35`
+  may need retuning. `app/pages/modes.lua`'s `channelRawToUs()` handles
+  *two* different raw scales defensively (`-1200..1200` and
+  `700..2300`) — this fix does not; if the channel value doesn't behave
+  as expected, that's the first place to look.
+- Whether `MSP_RX_MAP` (cmd 64) is answered identically across all
+  supported FC/API versions — untested against real firmware.
+
+## How to test
+
+1. Simulator or radio — connect, open the dashboard widget.
+2. Watch console output for anything from `msp_rx_map`, `rxMap`, or
+   `flightmode.lua` — a crash there means the RX_MAP decode or the
+   channel-source resolution broke something.
+3. Arm, raise throttle past the old threshold, confirm `"inflight"`.
+4. Lower throttle without disarming (simulate a momentary blip) —
+   dashboard should **stay** `"inflight"` (this is the
+   hold-while-armed fix; previously it may have flipped to
+   `"postflight"`).
+5. Disarm — confirm `"postflight"`.
+6. **The actual bug repro**: rearm, raise throttle past threshold again
+   — dashboard should return to `"inflight"`. Repeat with **governor
+   off** specifically, since that's what the original report called out.
+7. If the dashboard doesn't respond as expected, first suspect the
+   channel-value scale (see "Biggest open risk" above) — add a debug
+   print of `resolveThrottleChannelValue(widget)`'s raw return value
+   next to the stick position to see what range it's actually reporting.
+
+## wfsuite (wingflight-lua-ethos-suite) port
+
+Same branch name, same fix, ported into
+`C:\Github\wingflight-lua-ethos-suite` (same session). Structurally
+wfsuite's `tasks/session.lua`/`widgets/dashboard.lua` mirror
+rotorflight's closely enough that the same edits applied cleanly at the
+equivalent anchor points (wfsuite has no `governorConfig` MSP fetch —
+no such firmware concept for fixed-wing — but `governorState` still
+exists as a dead/always-nil field, so `isGovernorActive()` is a
+harmless no-op there and `inFlight()` always falls through to the
+throttle check, which is correct for a plane anyway).
+
+**Left as a known follow-up, not attempted here**: wfsuite may want its
+own, differently-tuned `inFlight()` eventually — e.g. airspeed-based
+rather than throttle-based flight detection, since "throttle above X%"
+is a much weaker signal for a glider or a plane on a long descent than
+for a helicopter. The current port is a same-mechanism-for-now parity
+fix, not a wfsuite-specific redesign. See `flightmode.lua`'s own header
+comment there.
+
+## Git references
+
+- Pre-rewrite flight-mode task:
+  `git show 5069ec32^:src/rfsuite/tasks/scheduler/events/tasks/flightmode.lua`
+- Pre-rewrite RX-channel population:
+  `simulators/X18_EU@nightly26/scripts/rfsuite/tasks/scheduler/events/tasks/rxmap.lua`
+  (legacy simulator copy still in the working tree)
+- Pre-rewrite RX_MAP MSP command definition:
+  `simulators/X18_EU@nightly26/scripts/rfsuite/tasks/scheduler/msp/api/RX_MAP.lua`
+- The rewrite PR: #2256 ("RFSuite - Total rewrite"), commit `5069ec32`

--- a/src/rfsuite/lib/msp_rx_map.lua
+++ b/src/rfsuite/lib/msp_rx_map.lua
@@ -1,0 +1,63 @@
+-- Message-builder for MSP_RX_MAP (cmd 64, read-only here -- this suite never
+-- writes it). Standard MultiWii-lineage command: 8 bytes, each a U8 giving
+-- the physical RX channel index for one logical control -- not
+-- Rotorflight-specific, but the collective/throttle split (heli-specific)
+-- matches Rotorflight's own field naming.
+--
+-- Restores what widgets/dashboard/flightmode.lua's inFlight() needs to read
+-- the *radio's own* throttle channel (a local, instant, always-accurate
+-- signal) rather than the FC's telemetry-reported throttle_percent -- see
+-- that file's own header comment for why. Fetched once per connect by
+-- tasks/session.lua, same as lib/msp_handshake.lua's reads.
+
+if package.loaded["rfsuite.lib.msp_rx_map"] then
+  return package.loaded["rfsuite.lib.msp_rx_map"]
+end
+
+local requireModule = package.loaded["rfsuite.lib.require"] or assert(loadfile("lib/require.lua"))()
+local mspcodec = requireModule("lib/mspcodec.lua")
+
+local READ_COMMAND = 64
+
+local SIMULATOR_RESPONSE = {
+  0, -- aileron
+  1, -- elevator
+  2, -- rudder
+  3, -- collective
+  4, -- throttle
+  5, -- aux1
+  6, -- aux2
+  7, -- aux3
+}
+
+local msp_rx_map = {
+  READ_COMMAND = READ_COMMAND,
+}
+
+function msp_rx_map.decode(buf)
+  buf.offset = 1
+  return {
+    aileron = mspcodec.readU8(buf),
+    elevator = mspcodec.readU8(buf),
+    rudder = mspcodec.readU8(buf),
+    collective = mspcodec.readU8(buf),
+    throttle = mspcodec.readU8(buf),
+    aux1 = mspcodec.readU8(buf),
+    aux2 = mspcodec.readU8(buf),
+    aux3 = mspcodec.readU8(buf),
+  }
+end
+
+function msp_rx_map.buildReadMessage(onData, onError)
+  return {
+    command = READ_COMMAND,
+    processReply = function(_, buf)
+      onData(msp_rx_map.decode(buf))
+    end,
+    errorHandler = onError,
+    simulatorResponse = SIMULATOR_RESPONSE,
+  }
+end
+
+package.loaded["rfsuite.lib.msp_rx_map"] = msp_rx_map
+return msp_rx_map

--- a/src/rfsuite/tasks/session.lua
+++ b/src/rfsuite/tasks/session.lua
@@ -37,6 +37,7 @@ local DiySensor = requireModule("lib/diy_sensor.lua")
 local telemetryConfig = requireModule("lib/msp_telemetry_config.lua")
 local flightTimer = requireModule("tasks/flight_timer.lua")
 local debugLog = requireModule("lib/debug_log.lua")
+local rxMapApi = requireModule("lib/msp_rx_map.lua")
 
 local TELEMETRY_VALUE_INTERVAL = 0.5
 local PROFILE_INTERVAL = 0.5
@@ -124,6 +125,13 @@ local session = {
   -- armingDisableFlagsToString() for how the dashboard's governor/armflags
   -- objects turn this into a human-readable reason list.
   armDisableFlags = nil,
+  -- Physical RX channel index for each logical control (MSP_RX_MAP, cmd
+  -- 64), read once per connect same as the rest of runHandshake(). Lets
+  -- widgets/dashboard/flightmode.lua resolve the radio's own throttle
+  -- channel via system.getSource({category = CATEGORY_CHANNEL, member =
+  -- rxMap.throttle}) -- a local, instant signal, not FC telemetry -- see
+  -- that file's own header for why this matters.
+  rxMap = nil,
 }
 
 local localSmartFuel = SmartFuel.new()
@@ -317,6 +325,7 @@ local function flush()
     bblUsed = session.bblUsed,
     isArmed = session.isArmed,
     armDisableFlags = session.armDisableFlags,
+    rxMap = session.rxMap,
   })
 end
 
@@ -621,6 +630,13 @@ local function runHandshake(mspQueue, protocol)
     end))
   end
 
+  if not session.rxMap then
+    mspQueue:add(rxMapApi.buildReadMessage(function(data)
+      session.rxMap = data
+      publish()
+    end))
+  end
+
   -- Fetched regardless of protocol (cheap, and tasks/elrs_sensors.lua wants
   -- the same slot data for its own SID-relevance filtering on CRSF) -- retry
   -- in wakeup() if the first read exhausts the queue's own per-message tries.
@@ -672,6 +688,7 @@ local function setConnected(value, mspQueue, protocol)
     session.fuelPercent = nil
     session.governorMode = nil
     session.governorState = nil
+    session.rxMap = nil
     session.telemetrySlots = nil
     session.pidProfile = nil
     session.rateProfile = nil

--- a/src/rfsuite/widgets/dashboard.lua
+++ b/src/rfsuite/widgets/dashboard.lua
@@ -910,6 +910,7 @@ local function create()
     fuelPercent = nil,
     governorMode = nil,
     governorState = nil,
+    rxMap = nil,
     mspTransport = nil,
     pidProfile = nil,
     rateProfile = nil,
@@ -1042,6 +1043,7 @@ local function update(widget, snapshot)
   widget.fuelPercent = snapshot.fuelPercent
   widget.governorMode = snapshot.governorMode
   widget.governorState = snapshot.governorState
+  widget.rxMap = snapshot.rxMap
   widget.mspTransport = snapshot.mspTransport
   widget.pidProfile = snapshot.pidProfile
   widget.rateProfile = snapshot.rateProfile

--- a/src/rfsuite/widgets/dashboard/flightmode.lua
+++ b/src/rfsuite/widgets/dashboard/flightmode.lua
@@ -1,4 +1,31 @@
 -- Old dashboard flight-status state machine, adapted for Lite widget state.
+--
+-- inFlight()'s throttle check used to read the *radio's own* throttle
+-- channel directly (pre-rewrite tasks/scheduler/events/tasks/flightmode.lua:
+-- `rfsuite.session.rx.values.throttle`, via
+-- system.getSource({category = CATEGORY_CHANNEL, member = <RX_MAP throttle
+-- index>})) -- a local signal, always current, independent of the aircraft.
+-- The "Total rewrite" (#2256) swapped that for the FC's own telemetry-
+-- reported throttle_percent sensor (tasks/session.lua), because the RX_MAP
+-- fetch (lib/msp_rx_map.lua) hadn't been ported yet -- see
+-- lib/msp_handshake.lua's own "Deliberately excludes rxmap" comment. That
+-- swap is what's being undone here: a telemetry sensor has to actually be
+-- broadcast and resolved over the link, and (self-caught live) simply
+-- doesn't behave the same as raw stick position once the governor is off --
+-- the dashboard could get stuck showing "postflight" after a rearm because
+-- throttle_percent never convincingly crossed THROTTLE_THRESHOLD again.
+-- resolveThrottleChannelValue() below restores the original radio-channel
+-- read (session.rxMap, fetched once per connect by tasks/session.lua),
+-- falling back to the telemetry sensor only if RX_MAP hasn't resolved yet
+-- (older FC, or still mid-handshake) rather than never detecting flight.
+--
+-- Tracker:update() also restores two rules the rewrite dropped from the
+-- same pre-rewrite determineMode(): resetting to "preflight" on a fresh
+-- disarmed->armed edge (rather than carrying over whatever the previous
+-- flight left in `current`), and holding "inflight" for as long as the
+-- aircraft stays armed once a flight has genuinely started, so a momentary
+-- gap in the spool-up check doesn't bounce the dashboard to "postflight"
+-- mid-flight -- see that function's own comment.
 
 if package.loaded["rfsuite.widgets.dashboard.flightmode"] then
   return package.loaded["rfsuite.widgets.dashboard.flightmode"]
@@ -12,9 +39,46 @@ local function isGovernorActive(value)
   return type(value) == "number" and value >= 4 and value <= 8
 end
 
+-- Resolves (and caches, on the widget itself) a Source for the radio's own
+-- throttle channel, keyed off session.rxMap.throttle (the physical channel
+-- index reported by MSP_RX_MAP -- see lib/msp_rx_map.lua). Re-resolves only
+-- when that index changes (a different craft's RX_MAP fetched on
+-- reconnect); the resolved Source itself is transmitter-side and stays
+-- valid across reconnects to the *same* channel index, so it's fine to
+-- reuse. Returns nil (not 0) whenever the channel can't be read yet, so
+-- callers can tell "no data" apart from "stick at low end".
+local function resolveThrottleChannelValue(widget)
+  local rxMap = widget.rxMap
+  local member = rxMap and rxMap.throttle
+  if type(member) ~= "number" then return nil end
+
+  if widget._throttleChannelMember ~= member then
+    if system and system.getSource and CATEGORY_CHANNEL ~= nil then
+      widget._throttleChannelSource = system.getSource({category = CATEGORY_CHANNEL, member = member, options = 0})
+    else
+      widget._throttleChannelSource = nil
+    end
+    widget._throttleChannelMember = member
+  end
+
+  local source = widget._throttleChannelSource
+  if not source then return nil end
+  local value = source:value()
+  if type(value) ~= "number" then return nil end
+  return value
+end
+
 local function inFlight(widget)
   if not widget or widget.isArmed ~= true or widget.connected ~= true then return false end
   if isGovernorActive(widget.governorState) then return true end
+
+  local channelThrottle = resolveThrottleChannelValue(widget)
+  if channelThrottle ~= nil then
+    return channelThrottle > THROTTLE_THRESHOLD
+  end
+
+  -- RX_MAP not resolved yet -- fall back to the FC's own telemetry-reported
+  -- throttle_percent rather than never detecting flight at all.
   local throttle = widget.throttlePercent
   return type(throttle) == "number" and throttle > THROTTLE_THRESHOLD
 end
@@ -26,19 +90,33 @@ function Tracker:reset()
   self.current = "preflight"
   self.lastFlightMode = nil
   self.hasBeenInFlight = false
+  self.lastArmed = false
 end
 
 function Tracker:update(widget)
   widget = widget or {}
   local connected = widget.connected == true
+  local armed = widget.isArmed == true
   local current = self.current or "preflight"
   local mode
 
   if (current == "inflight" or current == "postflight") and not connected then
     self.hasBeenInFlight = true
     mode = "postflight"
+  elseif armed and not self.lastArmed then
+    -- Fresh disarmed->armed edge: start this flight's own detection over
+    -- rather than carrying over the previous flight's hasBeenInFlight, so
+    -- a rearm doesn't depend on inFlight(widget) already reading true on
+    -- this exact tick to leave "postflight".
+    self.hasBeenInFlight = false
+    mode = "preflight"
   elseif inFlight(widget) then
     self.hasBeenInFlight = true
+    mode = "inflight"
+  elseif armed and self.hasBeenInFlight then
+    -- Hold "inflight" while still armed even if this tick's spool-up check
+    -- momentarily reads false -- a transient channel/telemetry gap must not
+    -- flip the dashboard to "postflight" mid-flight.
     mode = "inflight"
   elseif self.hasBeenInFlight then
     mode = "postflight"
@@ -46,6 +124,7 @@ function Tracker:update(widget)
     mode = "preflight"
   end
 
+  self.lastArmed = armed
   self.current = mode
   return mode
 end


### PR DESCRIPTION
Fix dashboard stuck on postflight after rearm (governor off)

widgets/dashboard/flightmode.lua decides "are we flying" as isArmed
AND (governor active OR throttle > 35%). The "Total rewrite" (#2256)
swapped the throttle signal from the radio's own throttle channel
(pre-rewrite tasks/scheduler/events/tasks/flightmode.lua:
session.rx.values.throttle, a local system.getSource(CATEGORY_CHANNEL)
read) for the FC's own telemetry-reported throttle_percent sensor,
because the RX_MAP fetch hadn't been ported yet (see
lib/msp_handshake.lua's own "Deliberately excludes rxmap" comment).
That's a materially different signal, especially with governor off,
and the same rewrite also dropped two state-machine rules: resetting
to "preflight" on a fresh disarmed->armed edge, and holding "inflight"
while still armed despite a momentary spool-up-check gap. Together
these let the dashboard get stuck showing "postflight" after a rearm.

- New lib/msp_rx_map.lua: reads MSP_RX_MAP (cmd 64) once per connect.
- tasks/session.lua: fetches/publishes/resets session.rxMap.
- widgets/dashboard.lua: threads rxMap through to the widget.
- widgets/dashboard/flightmode.lua: reads the radio's throttle channel
  via rxMap.throttle (falling back to telemetry throttle_percent if
  RX_MAP hasn't resolved yet), and restores the two dropped
  state-machine rules.

Untested against real hardware/simulator -- see
docs/dev-notes-dashboard-flightmode-fix.md for root-cause detail, what
was and wasn't verified, and a test checklist.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
